### PR TITLE
Added check for default 'vcredist-x64' Juju resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Custom URL for FreeRDP dependency can be configured by the operator of the charm
     juju config installer-url=http://example.com/FreeRDPWebConnect.msi
 
 You can browse to `http://ip-address:port` in order to use it separately from OpenStack.
+
+**NOTE**: The charm has usable default resources for free RDP msi and zip installers. The default resource for `vcredist-x64` is not usable and it must be manually given at deploy time. The Visual C++ Redistributable x64 installer can be obtained from the following [url](https://www.microsoft.com/en-us/download/details.aspx?id=40784).

--- a/lib/Modules/FreeRdpHooks/FreeRdpHooks.psm1
+++ b/lib/Modules/FreeRdpHooks/FreeRdpHooks.psm1
@@ -30,11 +30,17 @@ function Get-Vcredist {
         try {
             Write-JujuWarning "Trying to get vcredist Juju resource"
             $vcredistPath = Get-JujuResource -Resource "vcredist-x64"
+            $bytes = Get-Content $vcredistPath -TotalCount 31 -Encoding Byte
+            $str = [string]::join("", [char[]]$bytes)
+            if ($str -eq $DEFAULT_JUJU_RESOURCE_CONTENT) {
+                Throw "Cannot use the default Juju resource for 'vcredist-x64'. Manually attach it or set the config option 'vcredist-url'."
+            }
             return $vcredistPath
         } catch {
-            Write-JujuWarning "Failed downloading vcredist resource: $_"
+            Write-JujuWarning "Failed downloading vcredist Juju resource: $_"
             Write-JujuWarning "Falling back to file download"
         }
+        Write-JujuWarning "Using default download URL for vcredist-x64: $FREE_RDP_VCREDIST"
         $url = $FREE_RDP_VCREDIST
     } else {
         Write-JujuInfo ("'vcredist-url' config option is set to: '{0}'" -f $vcredistUrl)

--- a/lib/Modules/OpenStackCommon/OpenStackCommon.psm1
+++ b/lib/Modules/OpenStackCommon/OpenStackCommon.psm1
@@ -22,6 +22,7 @@ Import-Module JujuHelper
 
 $COMPUTERNAME = [System.Net.Dns]::GetHostName()
 $SUPPORTED_OPENSTACK_RELEASES = @('liberty', 'mitaka', 'newton')
+$DEFAULT_JUJU_RESOURCE_CONTENT = "Cloudbase default Juju resource"
 
 # Nova constants
 $NOVA_PRODUCT = @{


### PR DESCRIPTION
Due to licensing issues, the charm can't have a default usable resource
for Visual C++ Redistributable. At the moment, a charm with resources
cannot be published without a default resource for every resource.
This commit adds a check for the default Cloudbase Juju resource uploaded
in charm store for 'vcredist-x64', in order to error out in case users
rely on that default one.